### PR TITLE
tor.us has node/npm version requirements

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "yam",
   "version": "0.1.0",
   "private": true,
+  "engines": {
+    "node": ">=14.17.0",
+    "npm": "~6.x"
+  },
   "dependencies": {
     "@apollo/client": "^3.4.1",
     "@fortawesome/fontawesome-svg-core": "^1.2.35",


### PR DESCRIPTION
We need to specifiy the minimum build requirements for node/npm so that
the build system in Digital Ocean can use the correct node binary.

The following is an excerpt from the build log

```
[2021-08-11 14:15:23] error @toruslabs/torus-embed@1.12.1: The engine
"node" is incompatible with this module. Expected version ">=14.17.0".
Got "12.22.4"
[2021-08-11 14:15:23] error Found incompatible module.
```

References:
-
https://github.com/torusresearch/torus-embed/blob/master/package.json#L124