### PR TITLE
remove OneSignal

### DIFF
--- a/OneSignalSDKUpdaterWorker.js
+++ b/OneSignalSDKUpdaterWorker.js
@@ -1,1 +1,0 @@
-importScripts('https://cdn.onesignal.com/sdks/OneSignalSDKWorker.js')

--- a/OneSignalSDKWorker.js
+++ b/OneSignalSDKWorker.js
@@ -1,1 +1,0 @@
-importScripts('https://cdn.onesignal.com/sdks/OneSignalSDKWorker.js')

--- a/public/OneSignalSDKUpdaterWorker.js
+++ b/public/OneSignalSDKUpdaterWorker.js
@@ -1,1 +1,0 @@
-importScripts('https://cdn.onesignal.com/sdks/OneSignalSDKWorker.js');

--- a/public/OneSignalSDKWorker.js
+++ b/public/OneSignalSDKWorker.js
@@ -1,1 +1,0 @@
-importScripts('https://cdn.onesignal.com/sdks/OneSignalSDKWorker.js');

--- a/public/index.html
+++ b/public/index.html
@@ -38,15 +38,6 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
     <title>Polly Finance</title>
-    <script src="https://cdn.onesignal.com/sdks/OneSignalSDK.js" async=""></script>
-    <script>
-      window.OneSignal = window.OneSignal || [];
-      OneSignal.push(function() {
-        OneSignal.init({
-          appId: "57d4037b-bdc3-4c84-9d3b-862d7d11a1df",
-        });
-      });
-    </script>
   </head>
   <body>
     <noscript>You need to enable JavaScript to view Bao.Finance</noscript>


### PR DESCRIPTION
As far as I know, this is an artifact of forking and isn't used, and may even be sending basic analytics data to the wrong OneSignal account.

If we can delete it, privacy blockers will be happy and page load times will improve a tiny bit bit.