### PR TITLE
Add try catch for failed or rejected transactions. 

### DIFF
--- a/src/bao/utils.js
+++ b/src/bao/utils.js
@@ -215,11 +215,12 @@ export const unstake = async (masterChefContract, pid, amount, account, ref) =>
 	)
 
 export const harvest = async (masterChefContract, pid, account) =>
-	new Promise((resolve) =>
+	new Promise((resolve, reject) =>
 		masterChefContract.methods
 			.claimReward(pid)
 			.send({ from: account })
-			.on('receipt', (tx) => resolve(tx.transactionHash)),
+			.on('receipt', (tx) => resolve(tx.transactionHash))
+			.on('error', (error) => reject(error))
 	)
 
 export const getStaked = async (masterChefContract, pid, account) => {

--- a/src/hooks/useReward.ts
+++ b/src/hooks/useReward.ts
@@ -9,8 +9,15 @@ const useReward = (pid: number) => {
   const masterChefContract = getMasterChefContract(bao)
 
   const handleReward = useCallback(async () => {
-    const txHash = await harvest(masterChefContract, pid, account)
-    console.log(txHash)
+    var txHash;
+    try {
+      txHash = await harvest(masterChefContract, pid, account)
+      console.log(txHash)
+
+    } catch(error) {
+      console.log("failed to harvest");
+      console.log(error);
+    }
     return txHash
   }, [account, pid, bao])
 


### PR DESCRIPTION
Allows the harvest button to return to enabled after the user rejects a transaction.